### PR TITLE
Fix private test assertion.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -38,7 +38,7 @@ describe("readme", function() {
     it("does not write installation instructions", function(done) {
       nixt()
         .expect(function(result) {
-          if (result.stdout.match("installation")) {
+          if (result.stdout.match("Installation")) {
             return new Error("installation instructions should not be displayed for private packages")
           }
         })


### PR DESCRIPTION
This test was passing whether `{{^private}}` was in the template or not because `String#match` with a `String` as an arg is case-sensitive.

Related to #3.