### PR TITLE
Treat license: private as private: true.

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ try {
   return console.error("Invalid JSON file: %s", pkgPath)
 }
 
-pkg.private = pkg.private || false;
+pkg.private = pkg.private || pkg.license === "private" || false;
 
 if (argv.travis) {
   if (pkg.repository && pkg.repository.url && gh(pkg.repository.url)) {

--- a/test/fixtures/private-license/package.json
+++ b/test/fixtures/private-license/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "private-true",
-  "private": "true",
+  "name": "private-license",
   "description": "A sample app.",
   "scripts": {
     "test": "mocha"
@@ -11,5 +10,5 @@
   },
   "keywords": ["foo", "bar"],
   "author": "Bob Boilerplate",
-  "license": "MIT"
+  "license": "private"
 }

--- a/test/index.js
+++ b/test/index.js
@@ -35,14 +35,25 @@ describe("readme", function() {
         .end(done)
     })
 
-    it("does not write installation instructions", function(done) {
+    it("does not write installation instructions for private: true", function(done) {
       nixt()
         .expect(function(result) {
           if (result.stdout.match("installation")) {
-            return new Error("installation instructions should not be displayed for private packages")
+            return new Error("installation instructions should not be displayed for private: true packages")
           }
         })
         .run('./index.js test/fixtures/private/package.json')
+        .end(done)
+    })
+
+    it("does not write installation instructions for license: private", function(done) {
+      nixt()
+        .expect(function(result) {
+          if (result.stdout.match("Installation")) {
+            return new Error("installation instructions should not be displayed for license: private packages")
+          }
+        })
+        .run('./index.js test/fixtures/private-license/package.json')
         .end(done)
     })
     


### PR DESCRIPTION
This is an alternative means for communicating that packages are private. Doesn't have publish prevention support from npm, but I've seen it used around the place and seems a good way to flag proprietary code i.e.  I often see private: true with a license which can't possibly make sense for private code.