### PR TITLE
Improve spacing and new lines in Readme.md

### DIFF
--- a/template.md
+++ b/template.md
@@ -1,4 +1,4 @@
-# {{name}} {{#travis_url}}[![Build Status]({{travis_url}}.png?branch=master)]({{travis_url}}){{/travis_url}}
+# {{name}}{{#travis_url}} [![Build Status]({{travis_url}}.png?branch=master)]({{travis_url}}){{/travis_url}}
 
 {{description}}
 
@@ -21,16 +21,16 @@ npm install {{name}} --save
 {{/preferGlobal}}
 ```
 {{/private}}
-
 {{#usage}}
+
 ## Usage
 
 ```{{language}}
 {{{content}}}
 ```
 {{/usage}}
-
 {{#scripts.test}}
+
 ## Tests
 
 ```sh
@@ -58,7 +58,6 @@ None
 {{#devDepDetails}}
 - [{{name}}]({{repository.url}}): {{description}}
 {{/devDepDetails}}
-
 {{^devDepDetails}}
 None
 {{/devDepDetails}}


### PR DESCRIPTION
The generated Readme.md often contains a couple of Markdown lint warnings/errors relating to:
- MD009/no-trailing-spaces
- MD012/no-multiple-blanks

These warnings are only present when specific sections of the Readme template are not rendered. For example, if a Travis badge is not rendered, or if the Usage section is not rendered.

The proposed changes to the template consist of:
- moving the separating space between the Name and the Travis badge, so that the separating space is part of the rendering of Travis badge section. This prevents an unwanted trailing space being rendered for scenarios when no Travis badge is generated.
- removing the blank line between the two scenarios where devDepDetails either exists or does not exist. As both devDepDetails scenarios cannot exist at the same time, the blank line isn't needed.
- moving the blank lines between Tests and Usage so they are rendered as part of the usage and scripts.test sections. This avoids 2 blank lines being rendered if the usage section is not rendered