### PR TITLE
fix(pkg): Accept repository as string or undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,11 +77,7 @@ extensions.forEach(function (language) {
 var getDeps = function (deps) {
   return Object.keys(deps).map(function (depname) {
     var dep = require(path.resolve(path.dirname(argv._[0])) + '/node_modules/' + depname + '/package.json')
-    if (typeof (dep.repository) === 'string' || typeof (dep.repository) === 'undefined') {
-      dep.repository = { url: 'http://ghub.io/' + depname }
-    } else {
-      dep.repository.url = 'http://ghub.io/' + depname
-    }
+    dep.repository = 'https://ghub.io/' + depname
     return dep
   })
 }

--- a/index.js
+++ b/index.js
@@ -77,7 +77,7 @@ extensions.forEach(function (language) {
 var getDeps = function (deps) {
   return Object.keys(deps).map(function (depname) {
     var dep = require(path.resolve(path.dirname(argv._[0])) + '/node_modules/' + depname + '/package.json')
-    if (typeof(dep.repository) === 'string' || typeof(dep.repository) === 'undefined') {
+    if (typeof (dep.repository) === 'string' || typeof (dep.repository) === 'undefined') {
       dep.repository = { url: 'http://ghub.io/' + depname }
     } else {
       dep.repository.url = 'http://ghub.io/' + depname

--- a/index.js
+++ b/index.js
@@ -77,7 +77,11 @@ extensions.forEach(function (language) {
 var getDeps = function (deps) {
   return Object.keys(deps).map(function (depname) {
     var dep = require(path.resolve(path.dirname(argv._[0])) + '/node_modules/' + depname + '/package.json')
-    dep.repository.url = 'http://ghub.io/' + depname
+    if (typeof(dep.repository) === 'string' || typeof(dep.repository) === 'undefined') {
+      dep.repository = { url: 'http://ghub.io/' + depname }
+    } else {
+      dep.repository.url = 'http://ghub.io/' + depname
+    }
     return dep
   })
 }

--- a/template.md
+++ b/template.md
@@ -47,7 +47,7 @@ npm test
 ## Dependencies
 
 {{#depDetails}}
-- [{{name}}]({{repository.url}}): {{description}}
+- [{{name}}]({{repository}}): {{description}}
 {{/depDetails}}
 {{^depDetails}}
 None
@@ -56,7 +56,7 @@ None
 ## Dev Dependencies
 
 {{#devDepDetails}}
-- [{{name}}]({{repository.url}}): {{description}}
+- [{{name}}]({{repository}}): {{description}}
 {{/devDepDetails}}
 {{^devDepDetails}}
 None

--- a/test/index.js
+++ b/test/index.js
@@ -100,7 +100,7 @@ describe('readme', function () {
       assert(require(packagePath).repository.url.match('git://github.com/substack'))
       nixt()
         .run('./index.js test/fixtures/deps/package.json')
-        .stdout(/http:\/\/ghub\.io\/minimist/)
+        .stdout(/https:\/\/ghub\.io\/minimist/)
         .end(done)
     })
   })


### PR DESCRIPTION
Some packages have no repository inside package.json or (like js-yaml) it has a string as value instead of an object. (like { repository: "repourl" }).